### PR TITLE
Correct filter initial value

### DIFF
--- a/rover.py
+++ b/rover.py
@@ -46,7 +46,7 @@ def measure_light(timer):
     
     if lastSensor == 1 and currentValue == 0:
         if lightPeriod == 0:
-            lightPeriod = count
+            lightPeriod = count*2
         else:
             lightPeriod = round(count*2 * 0.5 + lightPeriod * 0.5) #filter results for more consistancy
     if currentValue == 0:


### PR DESCRIPTION
Count is tracking 1/2 the period so the light period is always count*2

This fixes the initial guess allowing the filter to settle sooner.